### PR TITLE
update prereq, update version num for patched file, fix README type

### DIFF
--- a/02_patcher.py
+++ b/02_patcher.py
@@ -8,13 +8,13 @@ import crcmod
 # (addr, orig, new (optional) )
 patches = {
     "2501": [
-        (0x0005E7A8, b"1K0909144E \x002501", None),  # Software number and version
+        (0x0005E7A8, b"1K0909144E \x002501", b"1K0909144E \x002502"),  # Software number and version
         (0x0005E221, b"\x64", b"\x00"),  # Disengage countdown
         (0x0005E283, b"\x32", b"\x00"),  # Min speed
         (0x0005FFFC, b"Ende", b"\xff\xff\xff\xff"),  # End of FW marker
     ],
     "3501": [
-        (0x0005D828, b"1K0909144R \x003501", None),  # Software number and version
+        (0x0005D828, b"1K0909144R \x003501", b"1K0909144R \x003502"),  # Software number and version
         (0x0005D289, b"\x64", b"\x00"),  # Disengage countdown
         (0x0005D2FA, b"\x14", b"\x00"),  # Min speed
         (0x0005FFFC, b"Ende", b"\xff\xff\xff\xff"),  # End of FW marker

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See the related [blog series](https://blog.willemmelching.nl/carhacking/2022/01/
  - Making changes to your EPS might have unintended consequences. You can lose power steering, or the steering motor may put large amounts of torque on the wheel unexpectedly. Ensure the patches to the calibration values are safe before using.
  - This may brick your EPS. Only attempt this if you're willing to replace the EPS if needed.
  - This was only tested by the author on a 2010 VW Golf with the 2501 FW. Your milage may vary on other firmware versions or cars. There are reports of things working as expected on the 3501 FW.
- - A [comma.ai panda](https://comma.ai/shop/products/panda-obd-ii-dongle) is needed to communicate over CAN, and the latest panda python library needs to be installed (`pip install -r requiremets.txt`).
+ - A [comma.ai panda](https://comma.ai/shop/products/panda-obd-ii-dongle) is needed to communicate over CAN, and the latest panda python library needs to be installed (`pip install -r requirements.txt`).
 
 ## Procedure
 ### Dump the existing firmware

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/commaai/panda.git@79f5e6fe860d4f84876f08ddeea00eb6361cb05d
+git+https://github.com/commaai/panda.git@95c4449d9624b7d34baa25f53a3ad967afa99df0
 crcmod==1.7
 tqdm==4.54.1


### PR DESCRIPTION
Updated panda commit version, fixes an issue on Comma 3X's which have panda connected via SPI rather than USB

Updated software version number on patched files, will be requirement when KWP2000 is added to openpilot for the purposes of fingerprinting / vehicle ID / parameter ID or query

Fixed a README typo